### PR TITLE
Support eclipse; targetCompatibility=1.6 explicit; corrected codenarc co...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ idea/
 *.iml
 *.ipr
 *.iws
+
+# ECLIPSE
+*.classpath
+*.project
+*.settings
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,11 @@ buildscript {
 
 allprojects {
     apply plugin: 'idea'
+	apply plugin: 'eclipse'
+	
     apply plugin: 'groovy'
+	targetCompatibility = 1.6
+	
     apply plugin: 'codenarc'
     apply plugin: 'cobertura'
 
@@ -29,7 +33,7 @@ allprojects {
     }
 
     codenarc {
-        toolVersion = '0.22'
+        toolVersion = '0.23'
         configFile = file("${rootProject.projectDir}/config/codenarc/rules.groovy")
     }
 


### PR DESCRIPTION
I do not have Java6 installed so targetCompatibility stops java.lang.VerifyError
