### PR TITLE
fixed infinite loop issue in table rendering

### DIFF
--- a/pdf/src/main/groovy/com/craigburke/document/builder/render/TableRenderer.groovy
+++ b/pdf/src/main/groovy/com/craigburke/document/builder/render/TableRenderer.groovy
@@ -32,7 +32,7 @@ class TableRenderer implements Renderable {
         }
 
         if (parsedAndRendered) {
-            parseEnd = Math.min(rowRenderers.size() - 1, parseEnd + 1)
+            parseEnd = Math.min(rowRenderers.size() - 1, parseEnd)
             parseStart = parseEnd
         }
         else {


### PR DESCRIPTION
Changed the parseEnd counter to start from previous value where it left this worked for me.
my pdf is getting generated successfully.
