### PR TITLE
Support for standard paper sizes (ISO 216) and orientation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 allprojects {
+    apply plugin: 'maven'
     apply plugin: 'groovy'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -18,7 +19,7 @@ allprojects {
     apply plugin: 'nebula.provided-base'
 
     group = 'com.craigburke.document'
-    version = '0.4.15'
+    version = '0.4.16-SNAPSHOT'
     targetCompatibility = 1.6
 
     repositories {

--- a/core/src/main/groovy/com/craigburke/document/core/Dimension.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Dimension.groovy
@@ -1,0 +1,12 @@
+package com.craigburke.document.core
+
+import groovy.transform.Immutable
+
+/**
+ * Two dimensional width/height.
+ */
+@Immutable
+class Dimension {
+    BigDecimal width
+    BigDecimal height
+}

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -48,20 +48,30 @@ class Document extends BlockNode {
     /**
      * Set width and height of the document.
      *
-     * @param arg a Dimension instance, a List<Number> [width, height] or the name of a standard paper size ("a4", "letter", "legal")
+     * @param arg name of a standard paper size ("a4", "letter", "legal")
      */
-    void setSize(def arg) {
-        if (arg instanceof Dimension) {
-            width = inchToPoint(arg.width)
-            height = inchToPoint(arg.height)
-        } else if (arg instanceof List && arg.size() == 2) {
-            width = inchToPoint(arg[0])
-            height = inchToPoint(arg[1])
-        } else {
-            def size = PaperSize.get(arg.toString())
-            width = inchToPoint(size.width)
-            height = inchToPoint(size.height)
-        }
+    void setSize(String arg) {
+        setSize(PaperSize.get(arg))
+    }
+
+    /**
+     * Set width and height of the document.
+     *
+     * @param arg a Dimension instance
+     */
+    void setSize(Dimension arg) {
+        width = inchToPoint(arg.width)
+        height = inchToPoint(arg.height)
+    }
+
+    /**
+     * Set width and height of the document.
+     *
+     * @param args width, height
+     */
+    void setSize(List<Number> args) {
+        width = args[0]
+        height = args[1]
     }
 
     /**

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -9,9 +9,13 @@ import static com.craigburke.document.core.UnitUtil.inchToPoint
 class Document extends BlockNode {
     static Margin defaultMargin = new Margin(top: 72, bottom: 72, left: 72, right: 72)
 
+    private static final String PORTRAIT = 'portrait'
+    private static final String LANDSCAPE = 'landscape'
+
     int pageCount
-    final int width = inchToPoint(8.5)
-    final int height = inchToPoint(11)
+    int width = inchToPoint(PaperSize.LETTER.width)
+    int height = inchToPoint(PaperSize.LETTER.height)
+    String orientation = PORTRAIT
 
     def template
     def header
@@ -41,4 +45,40 @@ class Document extends BlockNode {
     List children = []
     List<EmbeddedFont> embeddedFonts = []
 
+    /**
+     * Set width and height of the document.
+     *
+     * @param arg a Dimension instance, a List<Number> [width, height] or the name of a standard paper size ("a4", "letter", "legal")
+     */
+    void setSize(def arg) {
+        if (arg instanceof Dimension) {
+            width = inchToPoint(arg.width)
+            height = inchToPoint(arg.height)
+        } else if (arg instanceof List && arg.size() == 2) {
+            width = inchToPoint(arg[0])
+            height = inchToPoint(arg[1])
+        } else {
+            def size = PaperSize.get(arg.toString())
+            width = inchToPoint(size.width)
+            height = inchToPoint(size.height)
+        }
+    }
+
+    /**
+     * Set document orientation.
+     *
+     * @param arg "portrait" or "landscape"
+     */
+    void setOrientation(String arg) {
+        arg = arg.toLowerCase()
+        if (arg != PORTRAIT && arg != LANDSCAPE) {
+            throw new IllegalArgumentException("invalid orientation: $arg, only '$PORTRAIT' or '$LANDSCAPE' allowed")
+        }
+        if (this.@orientation != arg) {
+            this.@orientation = arg
+            def tmp = width
+            width = height
+            height = tmp
+        }
+    }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -81,4 +81,8 @@ class Document extends BlockNode {
             height = tmp
         }
     }
+
+    boolean isLandscape() {
+        this.orientation == LANDSCAPE
+    }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/PaperSize.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/PaperSize.groovy
@@ -1,0 +1,39 @@
+package com.craigburke.document.core
+
+/**
+ * Standard paper size utility. Returned dimensions are inches.
+ */
+class PaperSize {
+
+    static final Dimension A1 = new Dimension(23.4, 33.1)
+    static final Dimension A2 = new Dimension(16.5, 23.4)
+    static final Dimension A3 = new Dimension(11.7, 16.5)
+    static final Dimension A4 = new Dimension(8.27, 11.7)
+    static final Dimension A5 = new Dimension(5.83, 8.27)
+    static final Dimension A6 = new Dimension(4.13, 5.83)
+    static final Dimension LETTER = new Dimension(8.5, 11)
+    static final Dimension LEGAL = new Dimension(8.5, 14)
+
+    static Dimension get(String name) {
+        switch (name.toLowerCase()) {
+            case 'a1':
+                return A1
+            case 'a2':
+                return A2
+            case 'a3':
+                return A3
+            case 'a4':
+                return A4
+            case 'a5':
+                return A5
+            case 'a6':
+                return A6
+            case 'letter':
+                return LETTER
+            case 'legal':
+                return LEGAL
+            default:
+                throw new IllegalArgumentException("invalid paper size: $name")
+        }
+    }
+}

--- a/core/src/main/groovy/com/craigburke/document/core/UnitCategory.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/UnitCategory.groovy
@@ -10,6 +10,7 @@ class UnitCategory {
     BigDecimal getInch() { this * UnitUtil.POINTS_PER_INCH }
     BigDecimal getCentimeters() { this * UnitUtil.POINTS_PER_CENTIMETER }
     BigDecimal getCentimeter() { this * UnitUtil.POINTS_PER_CENTIMETER }
+    BigDecimal getCm() { this * UnitUtil.POINTS_PER_CENTIMETER }
     BigDecimal getPt() { this }
     BigDecimal getPx() { this }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/UnitUtil.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/UnitUtil.groovy
@@ -6,7 +6,8 @@ package com.craigburke.document.core
  */
 class UnitUtil {
     static final BigDecimal POINTS_PER_INCH = 72
-    static final BigDecimal POINTS_PER_CENTIMETER = 28.346457
+    static final BigDecimal CENTIMETER_PER_INCH = 2.54
+    static final BigDecimal POINTS_PER_CENTIMETER = POINTS_PER_INCH / CENTIMETER_PER_INCH
     static final BigDecimal PICA_POINTS = 6
     static final BigDecimal TWIP_POINTS = 20
     static final BigDecimal EIGTH_POINTS = 8
@@ -19,6 +20,14 @@ class UnitUtil {
 
     static BigDecimal pointToInch(BigDecimal point) {
         point / POINTS_PER_INCH
+    }
+
+    static BigDecimal cmToPoint(BigDecimal cm) {
+        cm * POINTS_PER_CENTIMETER
+    }
+
+    static BigDecimal pointToCm(BigDecimal point) {
+        point / POINTS_PER_CENTIMETER
     }
 
     static BigDecimal pointToPica(BigDecimal point) {
@@ -61,4 +70,11 @@ class UnitUtil {
         emu / EMU_POINTS
     }
 
+    static BigDecimal inchToCm(BigDecimal inch) {
+        inch * CENTIMETER_PER_INCH
+    }
+
+    static BigDecimal cmToInch(BigDecimal inch) {
+        inch / CENTIMETER_PER_INCH
+    }
 }

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -50,6 +50,51 @@ class BuilderSpec extends Specification {
         testFile?.delete()
     }
 
+    def "create default letter size document"() {
+        when:
+        def result = builder.create {
+            document(margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 612 // 8.5 inch * 72 DPI
+        result.document.height == 792 // 11 inch * 72 DPI
+    }
+
+    def "create A4 document"() {
+        when:
+        def result = builder.create {
+            document(size: 'A4', margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 595 // 8.27 inch * 72 DPI
+        result.document.height == 842 // 11.7 inch * 72 DPI
+    }
+
+    def "use landscape orientation"() {
+        when:
+        def result = builder.create {
+            document(size: 'A4', orientation: 'landscape', margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'Landscape'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 842 // 11.7 inch * 72 DPI
+        result.document.height == 595 // 8.27 inch * 72 DPI
+    }
+
     def "use typographic units"() {
         when:
         builder.create {

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -80,6 +80,21 @@ class BuilderSpec extends Specification {
         result.document.height == 842 // 11.7 inch * 72 DPI
     }
 
+    def "create document with custom size"() {
+        when:
+        def result = builder.create {
+            document(size: [14.8.cm, 21.cm], margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 419 // 8.27 inch * 72 DPI
+        result.document.height == 595 // 11.7 inch * 72 DPI
+    }
+
     def "use landscape orientation"() {
         when:
         def result = builder.create {

--- a/pdf/build.gradle
+++ b/pdf/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':core')
-    compile 'org.apache.pdfbox:pdfbox:1.8.8'
+    compile 'org.apache.pdfbox:pdfbox:1.8.11'
 }
 
 project.ext {

--- a/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocument.groovy
+++ b/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocument.groovy
@@ -3,6 +3,7 @@ package com.craigburke.document.builder
 import com.craigburke.document.core.Document
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.edit.PDPageContentStream
 
 /**
@@ -36,8 +37,16 @@ class PdfDocument {
         currentPage.mediaBox.height - document.margin.bottom
     }
 
+    private PDRectangle getRectangle(BigDecimal width, BigDecimal height) {
+        new PDRectangle(width.floatValue(), height.floatValue())
+    }
+
     void addPage() {
         def newPage = new PDPage()
+        newPage.setMediaBox(getRectangle(document.width, document.height))
+        if(document.isLandscape()) {
+            newPage.setRotation(90)
+        }
         pages << newPage
         pageNumber++
 

--- a/word/build.gradle
+++ b/word/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':core')
 
-    String POI_VERSION = '3.10.1'
+    String POI_VERSION = '3.13'
 
     testCompile 'xml-apis:xml-apis:1.4.01'
     testCompile "org.apache.poi:poi:${POI_VERSION}"

--- a/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
+++ b/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
@@ -67,7 +67,7 @@ class WordDocumentBuilder extends DocumentBuilder {
                     w.sectPr {
                         w.pgSz('w:h': pointToTwip(document.height),
                                 'w:w': pointToTwip(document.width),
-                                'w:orient': 'portrait'
+                                'w:orient': document.orientation
                         )
                         w.pgMar('w:bottom': pointToTwip(document.margin.bottom),
                                 'w:top': pointToTwip(document.margin.top),


### PR DESCRIPTION
Letter paper size was hard-coded in Document. I added support for specifying paper size and also added support for shortcuts to some common standard paper sizes like "Letter", "Legal", "A4", "A5", etc.

I also added support for specifying orientation "portrait" and "landscape".

Orientation and paper size is set on the Document instance so it's not possible to have some pages portrait and some landscape.

Tested ok with Word and PDF.

https://en.wikipedia.org/wiki/ISO_216
