### PR TITLE
Load image from URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 allprojects {
+    apply plugin: 'maven'
     apply plugin: 'groovy'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -18,7 +19,7 @@ allprojects {
     apply plugin: 'nebula.provided-base'
 
     group = 'com.craigburke.document'
-    version = '0.4.15'
+    version = '0.4.16-SNAPSHOT'
     targetCompatibility = 1.6
 
     repositories {

--- a/core/src/main/groovy/com/craigburke/document/core/Image.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Image.groovy
@@ -1,5 +1,7 @@
 package com.craigburke.document.core
 
+import java.security.MessageDigest
+
 /**
  * Image node
  * @author Craig Burke
@@ -9,9 +11,45 @@ class Image extends BaseNode {
     ImageType type = ImageType.JPG
     Integer width
     Integer height
-    byte[] data
-    
-    void setType(String value) { 
-        type = Enum.valueOf(ImageType, value.toUpperCase()) 
+    private URL imageUrl
+    private byte[] imageData
+
+    void setType(String value) {
+        type = Enum.valueOf(ImageType, value.toUpperCase())
+    }
+
+    URL getUrl() {
+        imageUrl
+    }
+
+    void setUrl(String value) {
+        setUrl(value != null ? URI.create(value).toURL() : null)
+    }
+
+    void setUrl(URL value) {
+        imageUrl = value
+    }
+
+    byte[] getData() {
+        imageUrl?.bytes ?: imageData
+    }
+
+    void setData(byte[] data) {
+        imageData = Arrays.copyOf(data, data.length)
+    }
+
+    def withInputStream(Closure work) {
+        if(imageUrl != null) {
+            return imageUrl.withInputStream(work)
+        }
+        work.call(new ByteArrayInputStream(imageData))
+    }
+
+    String getHash() {
+        Formatter hexHash = new Formatter()
+        MessageDigest.getInstance('SHA-1').digest(getData()).each {
+            b -> hexHash.format('%02x', b)
+        }
+        hexHash.toString()
     }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Image.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Image.groovy
@@ -11,38 +11,22 @@ class Image extends BaseNode {
     ImageType type = ImageType.JPG
     Integer width
     Integer height
-    private URL imageUrl
-    private byte[] imageData
+    String url
+    byte[] data
 
     void setType(String value) {
         type = Enum.valueOf(ImageType, value.toUpperCase())
     }
 
-    URL getUrl() {
-        imageUrl
-    }
-
-    void setUrl(String value) {
-        setUrl(value != null ? URI.create(value).toURL() : null)
-    }
-
-    void setUrl(URL value) {
-        imageUrl = value
-    }
-
     byte[] getData() {
-        imageUrl?.bytes ?: imageData
-    }
-
-    void setData(byte[] data) {
-        imageData = Arrays.copyOf(data, data.length)
+        if(this.@data == null && url != null) {
+            this.data = new URL(url).bytes
+        }
+        this.@data
     }
 
     def withInputStream(Closure work) {
-        if(imageUrl != null) {
-            return imageUrl.withInputStream(work)
-        }
-        work.call(new ByteArrayInputStream(imageData))
+        work.call(new ByteArrayInputStream(getData()))
     }
 
     String getHash() {

--- a/core/src/main/groovy/com/craigburke/document/core/factory/ImageFactory.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/factory/ImageFactory.groovy
@@ -6,7 +6,6 @@ import com.craigburke.document.core.TextBlock
 
 import javax.imageio.ImageIO
 import java.awt.image.BufferedImage
-import java.security.MessageDigest
 
 /**
  * Factory for image nodes

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -171,6 +171,58 @@ class BuilderSpec extends Specification {
         thrown(Exception)
     }
 
+    def "Image can be loaded from URL"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(url: "http://dummyimage.com/600x400")
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.data != null
+        image.width == 600
+        image.height == 400
+    }
+
+    def "Image should have correct aspect ratio if only width is specified"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(data: imageData, width: 250.px) // cheeseburger.jpg is 500x431
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.width == 250
+        image.height == 215
+    }
+
+    def "Image should have correct aspect ratio if only height is specified"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(data: imageData, height: 216.px) // cheeseburger.jpg is 500x431
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.width == 250
+        image.height == 216
+    }
+
     def "create a simple paragraph"() {
         when:
         def result = builder.create {

--- a/pdf/build.gradle
+++ b/pdf/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':core')
-    compile 'org.apache.pdfbox:pdfbox:1.8.8'
+    compile 'org.apache.pdfbox:pdfbox:1.8.11'
 }
 
 project.ext {

--- a/word/build.gradle
+++ b/word/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':core')
 
-    String POI_VERSION = '3.10.1'
+    String POI_VERSION = '3.13'
 
     testCompile 'xml-apis:xml-apis:1.4.01'
     testCompile "org.apache.poi:poi:${POI_VERSION}"


### PR DESCRIPTION
Added support for specifying url: "http://foo.com/images/logo.png" in the image element.
I'm not 100% sure that the Image class should have this URL loading responsibility, but it's very convenient to be able to specify an URL directly in the builder DSL.

I also made it possible to specify either image width **or** height and the other value will be calculated based on image dimensions. Before my change it would take both width and height from the image metadata if you did not specify both width and height.

Now you can do like this: image(url: "http://foo.com/images/logo.png", width: 5.inch) and the height will be set with correct aspect ratio.
