### PR TITLE
Document properties (title, subject, keywords, etc)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 allprojects {
+    apply plugin: 'maven'
     apply plugin: 'groovy'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -18,7 +19,7 @@ allprojects {
     apply plugin: 'nebula.provided-base'
 
     group = 'com.craigburke.document'
-    version = '0.4.15'
+    version = '0.4.16-SNAPSHOT'
     targetCompatibility = 1.6
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,3 +10,16 @@ project.ext {
             url : 'https://www.mozilla.org/MPL/2.0/'
     ]
 }
+
+task updateVersion {
+    ant.propertyfile(
+        file: 'src/main/resources/document-builder.properties') {
+        entry( key: 'document-builder.version', value: project.version)
+    }
+    ant.replaceregexp(file: 'src/main/resources/document-builder.properties', match: /(?s)^#.*document/, replace: 'document')
+
+}
+
+tasks.withType(JavaCompile) {
+    compileTask -> compileTask.dependsOn updateVersion
+}

--- a/core/src/main/groovy/com/craigburke/document/core/Dimension.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Dimension.groovy
@@ -1,0 +1,12 @@
+package com.craigburke.document.core
+
+import groovy.transform.Immutable
+
+/**
+ * Two dimensional width/height.
+ */
+@Immutable
+class Dimension {
+    BigDecimal width
+    BigDecimal height
+}

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -17,6 +17,8 @@ class Document extends BlockNode {
     def header
     def footer
 
+    Map metadata = [:]
+
     private Map templateMap
 
     Map getTemplateMap() {

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -21,6 +21,8 @@ class Document extends BlockNode {
     def header
     def footer
 
+    Map metadata = [:]
+
     private Map templateMap
 
     Map getTemplateMap() {

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -48,20 +48,30 @@ class Document extends BlockNode {
     /**
      * Set width and height of the document.
      *
-     * @param arg a Dimension instance, a List<Number> [width, height] or the name of a standard paper size ("a4", "letter", "legal")
+     * @param arg name of a standard paper size ("a4", "letter", "legal")
      */
-    void setSize(def arg) {
-        if (arg instanceof Dimension) {
-            width = inchToPoint(arg.width)
-            height = inchToPoint(arg.height)
-        } else if (arg instanceof List && arg.size() == 2) {
-            width = inchToPoint(arg[0])
-            height = inchToPoint(arg[1])
-        } else {
-            def size = PaperSize.get(arg.toString())
-            width = inchToPoint(size.width)
-            height = inchToPoint(size.height)
-        }
+    void setSize(String arg) {
+        setSize(PaperSize.get(arg))
+    }
+
+    /**
+     * Set width and height of the document.
+     *
+     * @param arg a Dimension instance
+     */
+    void setSize(Dimension arg) {
+        width = inchToPoint(arg.width)
+        height = inchToPoint(arg.height)
+    }
+
+    /**
+     * Set width and height of the document.
+     *
+     * @param args width, height
+     */
+    void setSize(List<Number> args) {
+        width = args[0]
+        height = args[1]
     }
 
     /**

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -9,9 +9,13 @@ import static com.craigburke.document.core.UnitUtil.inchToPoint
 class Document extends BlockNode {
     static Margin defaultMargin = new Margin(top: 72, bottom: 72, left: 72, right: 72)
 
+    private static final String PORTRAIT = 'portrait'
+    private static final String LANDSCAPE = 'landscape'
+
     int pageCount
-    final int width = inchToPoint(8.5)
-    final int height = inchToPoint(11)
+    int width = inchToPoint(PaperSize.LETTER.width)
+    int height = inchToPoint(PaperSize.LETTER.height)
+    String orientation = PORTRAIT
 
     def template
     def header
@@ -41,4 +45,40 @@ class Document extends BlockNode {
     List children = []
     List<EmbeddedFont> embeddedFonts = []
 
+    /**
+     * Set width and height of the document.
+     *
+     * @param arg a Dimension instance, a List<Number> [width, height] or the name of a standard paper size ("a4", "letter", "legal")
+     */
+    void setSize(def arg) {
+        if (arg instanceof Dimension) {
+            width = inchToPoint(arg.width)
+            height = inchToPoint(arg.height)
+        } else if (arg instanceof List && arg.size() == 2) {
+            width = inchToPoint(arg[0])
+            height = inchToPoint(arg[1])
+        } else {
+            def size = PaperSize.get(arg.toString())
+            width = inchToPoint(size.width)
+            height = inchToPoint(size.height)
+        }
+    }
+
+    /**
+     * Set document orientation.
+     *
+     * @param arg "portrait" or "landscape"
+     */
+    void setOrientation(String arg) {
+        arg = arg.toLowerCase()
+        if (arg != PORTRAIT && arg != LANDSCAPE) {
+            throw new IllegalArgumentException("invalid orientation: $arg, only '$PORTRAIT' or '$LANDSCAPE' allowed")
+        }
+        if (this.@orientation != arg) {
+            this.@orientation = arg
+            def tmp = width
+            width = height
+            height = tmp
+        }
+    }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Document.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Document.groovy
@@ -81,4 +81,8 @@ class Document extends BlockNode {
             height = tmp
         }
     }
+
+    boolean isLandscape() {
+        this.orientation == LANDSCAPE
+    }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Image.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Image.groovy
@@ -1,5 +1,7 @@
 package com.craigburke.document.core
 
+import java.security.MessageDigest
+
 /**
  * Image node
  * @author Craig Burke
@@ -9,9 +11,45 @@ class Image extends BaseNode {
     ImageType type = ImageType.JPG
     Integer width
     Integer height
-    byte[] data
-    
-    void setType(String value) { 
-        type = Enum.valueOf(ImageType, value.toUpperCase()) 
+    private URL imageUrl
+    private byte[] imageData
+
+    void setType(String value) {
+        type = Enum.valueOf(ImageType, value.toUpperCase())
+    }
+
+    URL getUrl() {
+        imageUrl
+    }
+
+    void setUrl(String value) {
+        setUrl(value != null ? URI.create(value).toURL() : null)
+    }
+
+    void setUrl(URL value) {
+        imageUrl = value
+    }
+
+    byte[] getData() {
+        imageUrl?.bytes ?: imageData
+    }
+
+    void setData(byte[] data) {
+        imageData = Arrays.copyOf(data, data.length)
+    }
+
+    def withInputStream(Closure work) {
+        if(imageUrl != null) {
+            return imageUrl.withInputStream(work)
+        }
+        work.call(new ByteArrayInputStream(imageData))
+    }
+
+    String getHash() {
+        Formatter hexHash = new Formatter()
+        MessageDigest.getInstance('SHA-1').digest(getData()).each {
+            b -> hexHash.format('%02x', b)
+        }
+        hexHash.toString()
     }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Image.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Image.groovy
@@ -11,38 +11,22 @@ class Image extends BaseNode {
     ImageType type = ImageType.JPG
     Integer width
     Integer height
-    private URL imageUrl
-    private byte[] imageData
+    String url
+    byte[] data
 
     void setType(String value) {
         type = Enum.valueOf(ImageType, value.toUpperCase())
     }
 
-    URL getUrl() {
-        imageUrl
-    }
-
-    void setUrl(String value) {
-        setUrl(value != null ? URI.create(value).toURL() : null)
-    }
-
-    void setUrl(URL value) {
-        imageUrl = value
-    }
-
     byte[] getData() {
-        imageUrl?.bytes ?: imageData
-    }
-
-    void setData(byte[] data) {
-        imageData = Arrays.copyOf(data, data.length)
+        if(this.@data == null && url != null) {
+            this.data = new URL(url).bytes
+        }
+        this.@data
     }
 
     def withInputStream(Closure work) {
-        if(imageUrl != null) {
-            return imageUrl.withInputStream(work)
-        }
-        work.call(new ByteArrayInputStream(imageData))
+        work.call(new ByteArrayInputStream(getData()))
     }
 
     String getHash() {

--- a/core/src/main/groovy/com/craigburke/document/core/PaperSize.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/PaperSize.groovy
@@ -1,0 +1,39 @@
+package com.craigburke.document.core
+
+/**
+ * Standard paper size utility. Returned dimensions are inches.
+ */
+class PaperSize {
+
+    static final Dimension A1 = new Dimension(23.4, 33.1)
+    static final Dimension A2 = new Dimension(16.5, 23.4)
+    static final Dimension A3 = new Dimension(11.7, 16.5)
+    static final Dimension A4 = new Dimension(8.27, 11.7)
+    static final Dimension A5 = new Dimension(5.83, 8.27)
+    static final Dimension A6 = new Dimension(4.13, 5.83)
+    static final Dimension LETTER = new Dimension(8.5, 11)
+    static final Dimension LEGAL = new Dimension(8.5, 14)
+
+    static Dimension get(String name) {
+        switch (name.toLowerCase()) {
+            case 'a1':
+                return A1
+            case 'a2':
+                return A2
+            case 'a3':
+                return A3
+            case 'a4':
+                return A4
+            case 'a5':
+                return A5
+            case 'a6':
+                return A6
+            case 'letter':
+                return LETTER
+            case 'legal':
+                return LEGAL
+            default:
+                throw new IllegalArgumentException("invalid paper size: $name")
+        }
+    }
+}

--- a/core/src/main/groovy/com/craigburke/document/core/UnitCategory.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/UnitCategory.groovy
@@ -10,6 +10,7 @@ class UnitCategory {
     BigDecimal getInch() { this * UnitUtil.POINTS_PER_INCH }
     BigDecimal getCentimeters() { this * UnitUtil.POINTS_PER_CENTIMETER }
     BigDecimal getCentimeter() { this * UnitUtil.POINTS_PER_CENTIMETER }
+    BigDecimal getCm() { this * UnitUtil.POINTS_PER_CENTIMETER }
     BigDecimal getPt() { this }
     BigDecimal getPx() { this }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/UnitUtil.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/UnitUtil.groovy
@@ -6,7 +6,8 @@ package com.craigburke.document.core
  */
 class UnitUtil {
     static final BigDecimal POINTS_PER_INCH = 72
-    static final BigDecimal POINTS_PER_CENTIMETER = 28.346457
+    static final BigDecimal CENTIMETER_PER_INCH = 2.54
+    static final BigDecimal POINTS_PER_CENTIMETER = POINTS_PER_INCH / CENTIMETER_PER_INCH
     static final BigDecimal PICA_POINTS = 6
     static final BigDecimal TWIP_POINTS = 20
     static final BigDecimal EIGTH_POINTS = 8
@@ -19,6 +20,14 @@ class UnitUtil {
 
     static BigDecimal pointToInch(BigDecimal point) {
         point / POINTS_PER_INCH
+    }
+
+    static BigDecimal cmToPoint(BigDecimal cm) {
+        cm * POINTS_PER_CENTIMETER
+    }
+
+    static BigDecimal pointToCm(BigDecimal point) {
+        point / POINTS_PER_CENTIMETER
     }
 
     static BigDecimal pointToPica(BigDecimal point) {
@@ -61,4 +70,11 @@ class UnitUtil {
         emu / EMU_POINTS
     }
 
+    static BigDecimal inchToCm(BigDecimal inch) {
+        inch * CENTIMETER_PER_INCH
+    }
+
+    static BigDecimal cmToInch(BigDecimal inch) {
+        inch / CENTIMETER_PER_INCH
+    }
 }

--- a/core/src/main/groovy/com/craigburke/document/core/Version.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/Version.groovy
@@ -1,0 +1,30 @@
+package com.craigburke.document.core
+
+/**
+ * Get version of document builder.
+ *
+ */
+class Version {
+
+    private static final String VERSION_PROPERTIES = 'document-builder.properties'
+
+    private Version() {}
+
+    static String getVersion() {
+        String version = 'unknown'
+        try {
+            Properties props = new Properties()
+            InputStream is = Version.class.getClassLoader().getResourceAsStream(VERSION_PROPERTIES)
+            try {
+                props.load(is)
+            } finally {
+                is.close()
+            }
+            version = props.getProperty('document-builder.version', version)
+        } catch (IOException e) {
+            e.printStackTrace()
+        }
+        version
+    }
+
+}

--- a/core/src/main/groovy/com/craigburke/document/core/factory/ImageFactory.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/factory/ImageFactory.groovy
@@ -6,7 +6,6 @@ import com.craigburke.document.core.TextBlock
 
 import javax.imageio.ImageIO
 import java.awt.image.BufferedImage
-import java.security.MessageDigest
 
 /**
  * Factory for image nodes

--- a/core/src/main/groovy/com/craigburke/document/core/test/BaseBuilderSpec.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/test/BaseBuilderSpec.groovy
@@ -90,6 +90,27 @@ abstract class BaseBuilderSpec extends Specification {
         currentMargin << testMargins
     }
 
+    def "document metadata"() {
+        when:
+        def result = builder.create {
+            document(metadata: [
+                    title: 'Groovy Document Builder',
+                    subject: 'Programatically build documents in a Groovy way',
+                    keywords: 'groovy,document,creator,word,doc,docx,pdf',
+                    description: 'The Groovy Document Builder is an awesome tool for the document oriented developer',
+                    author: 'Craig Burke'
+            ])
+        }
+
+
+        then:
+        result.document.metadata.title == 'Groovy Document Builder'
+        result.document.metadata.subject == 'Programatically build documents in a Groovy way'
+        result.document.metadata.keywords == 'groovy,document,creator,word,doc,docx,pdf'
+        result.document.metadata.description == 'The Groovy Document Builder is an awesome tool for the document oriented developer'
+        result.document.metadata.author == 'Craig Burke'
+    }
+
     def "create a simple table"() {
         when:
         builder.create {

--- a/core/src/main/resources/document-builder.properties
+++ b/core/src/main/resources/document-builder.properties
@@ -1,0 +1,1 @@
+document-builder.version=0.4.16-SNAPSHOT

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -50,6 +50,27 @@ class BuilderSpec extends Specification {
         testFile?.delete()
     }
 
+    def "document metadata"() {
+        when:
+        def result = builder.create {
+            document(metadata: [
+                    title: 'Groovy Document Builder',
+                    subject: 'Programatically build documents in a Groovy way',
+                    keywords: 'groovy,document,creator,word,doc,docx,pdf',
+                    description: 'The Groovy Document Builder is an awesome tool for the document oriented developer',
+                    author: 'Craig Burke'
+            ])
+        }
+
+
+        then:
+        result.document.metadata.title == 'Groovy Document Builder'
+        result.document.metadata.subject == 'Programatically build documents in a Groovy way'
+        result.document.metadata.keywords == 'groovy,document,creator,word,doc,docx,pdf'
+        result.document.metadata.description == 'The Groovy Document Builder is an awesome tool for the document oriented developer'
+        result.document.metadata.author == 'Craig Burke'
+    }
+
     def "use typographic units"() {
         when:
         builder.create {

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -50,6 +50,51 @@ class BuilderSpec extends Specification {
         testFile?.delete()
     }
 
+    def "create default letter size document"() {
+        when:
+        def result = builder.create {
+            document(margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 612 // 8.5 inch * 72 DPI
+        result.document.height == 792 // 11 inch * 72 DPI
+    }
+
+    def "create A4 document"() {
+        when:
+        def result = builder.create {
+            document(size: 'A4', margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 595 // 8.27 inch * 72 DPI
+        result.document.height == 842 // 11.7 inch * 72 DPI
+    }
+
+    def "use landscape orientation"() {
+        when:
+        def result = builder.create {
+            document(size: 'A4', orientation: 'landscape', margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'Landscape'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 842 // 11.7 inch * 72 DPI
+        result.document.height == 595 // 8.27 inch * 72 DPI
+    }
+
     def "use typographic units"() {
         when:
         builder.create {

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -80,6 +80,21 @@ class BuilderSpec extends Specification {
         result.document.height == 842 // 11.7 inch * 72 DPI
     }
 
+    def "create document with custom size"() {
+        when:
+        def result = builder.create {
+            document(size: [14.8.cm, 21.cm], margin: [top: 2.cm, bottom: 1.cm]) {
+                paragraph(align: 'center', font: [size: 24.pt]) {
+                    text 'ISO 216'
+                }
+            }
+        }
+
+        then:
+        result.document.width == 419 // 8.27 inch * 72 DPI
+        result.document.height == 595 // 11.7 inch * 72 DPI
+    }
+
     def "use landscape orientation"() {
         when:
         def result = builder.create {

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -171,6 +171,58 @@ class BuilderSpec extends Specification {
         thrown(Exception)
     }
 
+    def "Image can be loaded from URL"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(url: "http://dummyimage.com/600x400")
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.data != null
+        image.width == 600
+        image.height == 400
+    }
+
+    def "Image should have correct aspect ratio if only width is specified"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(data: imageData, width: 250.px) // cheeseburger.jpg is 500x431
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.width == 250
+        image.height == 215
+    }
+
+    def "Image should have correct aspect ratio if only height is specified"() {
+        when:
+        def result = builder.create {
+            document {
+                paragraph {
+                    image(data: imageData, height: 216.px) // cheeseburger.jpg is 500x431
+                }
+            }
+        }
+
+        then:
+        TextBlock paragraph = result.document.children[0]
+        Image image = paragraph.children[0]
+        image.width == 250
+        image.height == 216
+    }
+
     def "create a simple paragraph"() {
         when:
         def result = builder.create {

--- a/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/document/core/BuilderSpec.groovy
@@ -50,6 +50,27 @@ class BuilderSpec extends Specification {
         testFile?.delete()
     }
 
+    def "document metadata"() {
+        when:
+        def result = builder.create {
+            document(metadata: [
+                    title: 'Groovy Document Builder',
+                    subject: 'Programatically build documents in a Groovy way',
+                    keywords: 'groovy,document,creator,word,doc,docx,pdf',
+                    description: 'The Groovy Document Builder is an awesome tool for the document oriented developer',
+                    author: 'Craig Burke'
+            ])
+        }
+
+
+        then:
+        result.document.metadata.title == 'Groovy Document Builder'
+        result.document.metadata.subject == 'Programatically build documents in a Groovy way'
+        result.document.metadata.keywords == 'groovy,document,creator,word,doc,docx,pdf'
+        result.document.metadata.description == 'The Groovy Document Builder is an awesome tool for the document oriented developer'
+        result.document.metadata.author == 'Craig Burke'
+    }
+
     def "create default letter size document"() {
         when:
         def result = builder.create {

--- a/pdf/build.gradle
+++ b/pdf/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':core')
-    compile 'org.apache.pdfbox:pdfbox:1.8.8'
+    compile 'org.apache.pdfbox:pdfbox:1.8.11'
 }
 
 project.ext {

--- a/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocument.groovy
+++ b/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocument.groovy
@@ -3,6 +3,7 @@ package com.craigburke.document.builder
 import com.craigburke.document.core.Document
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.edit.PDPageContentStream
 
 /**
@@ -36,8 +37,16 @@ class PdfDocument {
         currentPage.mediaBox.height - document.margin.bottom
     }
 
+    private PDRectangle getRectangle(BigDecimal width, BigDecimal height) {
+        new PDRectangle(width.floatValue(), height.floatValue())
+    }
+
     void addPage() {
         def newPage = new PDPage()
+        newPage.setMediaBox(getRectangle(document.width, document.height))
+        if(document.isLandscape()) {
+            newPage.setRotation(90)
+        }
         pages << newPage
         pageNumber++
 

--- a/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocumentBuilder.groovy
+++ b/pdf/src/main/groovy/com/craigburke/document/builder/PdfDocumentBuilder.groovy
@@ -7,7 +7,6 @@ import com.craigburke.document.core.builder.DocumentBuilder
 import com.craigburke.document.core.builder.RenderState
 import groovy.transform.InheritConstructors
 import groovy.xml.MarkupBuilder
-import org.apache.pdfbox.Version
 import org.apache.pdfbox.pdmodel.PDDocumentInformation
 import org.apache.pdfbox.pdmodel.common.PDMetadata
 
@@ -19,7 +18,6 @@ import org.apache.pdfbox.pdmodel.common.PDMetadata
 class PdfDocumentBuilder extends DocumentBuilder {
 
     private static final String CREATOR = 'Groovy Document Builder'
-    private static final String VERSION = '0.4.16' // TODO Create version utility class
 
     PdfDocument pdfDocument
 
@@ -181,7 +179,7 @@ class PdfDocumentBuilder extends DocumentBuilder {
     private void addDocumentInfo(Map documentMetadata) {
         PDDocumentInformation info = pdfDocument.pdDocument.getDocumentInformation()
 
-        info.setProducer("PDFBox ${Version.getVersion()}")
+        info.setProducer("PDFBox ${org.apache.pdfbox.Version.getVersion()}")
 
         if (documentMetadata.keywords) {
             info.setKeywords(documentMetadata.keywords)
@@ -190,7 +188,7 @@ class PdfDocumentBuilder extends DocumentBuilder {
         info.setCreationDate(toGregorianCalendar(documentMetadata.created ?: new Date()))
         info.setModificationDate(toGregorianCalendar(documentMetadata.modified ?: new Date()))
 
-        info.setCreator("${CREATOR} ${VERSION}")
+        info.setCreator("${CREATOR} ${Version.getVersion()}")
         info.setAuthor(documentMetadata.author ?: documentMetadata.creator ?: CREATOR)
 
         if (documentMetadata.title) {

--- a/word/build.gradle
+++ b/word/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':core')
 
-    String POI_VERSION = '3.10.1'
+    String POI_VERSION = '3.13'
 
     testCompile 'xml-apis:xml-apis:1.4.01'
     testCompile "org.apache.poi:poi:${POI_VERSION}"

--- a/word/src/main/groovy/com/craigburke/document/builder/BasicDocumentPartTypes.groovy
+++ b/word/src/main/groovy/com/craigburke/document/builder/BasicDocumentPartTypes.groovy
@@ -9,7 +9,20 @@ enum BasicDocumentPartTypes implements DocumentPartType {
 
     DOCUMENT('document',
             'document.xml',
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+            'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument'
+    ),
+
+    CORE_PROPERTIES('core',
+            'docProps/core.xml',
+            'application/vnd.openxmlformats-package.core-properties+xml',
+            'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties'
+    ),
+
+    APP_PROPERTIES('app',
+            'docProps/app.xml',
+            'application/vnd.openxmlformats-officedocument.extended-properties+xml',
+            'http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties'
     ),
 
     HEADER('header',

--- a/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
+++ b/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
@@ -67,7 +67,7 @@ class WordDocumentBuilder extends DocumentBuilder {
                     w.sectPr {
                         w.pgSz('w:h': pointToTwip(document.height),
                                 'w:w': pointToTwip(document.width),
-                                'w:orient': 'portrait'
+                                'w:orient': document.orientation
                         )
                         w.pgMar('w:bottom': pointToTwip(document.margin.bottom),
                                 'w:top': pointToTwip(document.margin.top),

--- a/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
+++ b/word/src/main/groovy/com/craigburke/document/builder/WordDocumentBuilder.groovy
@@ -115,7 +115,7 @@ class WordDocumentBuilder extends DocumentBuilder {
                 if (metadata.subject) {
                     dc.subject(metadata.subject)
                 }
-                dc.creator(metadata.author ?: metadata.creator ?: CREATOR)
+                dc.creator(metadata.author ?: metadata.creator ?: this.CREATOR)
                 if (metadata.keywords) {
                     cp.keywords(metadata.keywords)
                 }


### PR DESCRIPTION
Adding document properties was much harder than expected, but I finally made it. I had to move code from WordDocument to WordDocumentBuilder and add relationships for app.xml and core.xml, and some other stuff.

In the document DSL you can now add a `metadata` `Map` like this:

```
document(font: [family: 'Arial', size: 12.pt],
                metadata: [company: 'Groovy Documents Inc.',
                           manager: 'Craig Burke', author: 'Göran Ehrsson',
                           subject: 'Test', title: 'Test of document properties'],
```
