### PR TITLE
EmbeddedFont with InputStream as an alternative to File

### DIFF
--- a/core/src/main/groovy/com/craigburke/document/core/EmbeddedFont.groovy
+++ b/core/src/main/groovy/com/craigburke/document/core/EmbeddedFont.groovy
@@ -6,6 +6,7 @@ package com.craigburke.document.core
  */
 class EmbeddedFont {
     File file
+    InputStream inputStream
     String name
     boolean italic = false
     boolean bold = false

--- a/pdf/src/main/groovy/com/craigburke/document/builder/PdfFont.groovy
+++ b/pdf/src/main/groovy/com/craigburke/document/builder/PdfFont.groovy
@@ -53,7 +53,13 @@ class PdfFont {
     }
 
     static void addFont(PDDocument document, EmbeddedFont embeddedFont) {
-        PDFont font = PDType0Font.load(document, embeddedFont.file)
+        PDFont font = null
+        if (embeddedFont.file) {
+            font = PDType0Font.load(document, embeddedFont.file)
+        }
+        else {
+            font = PDType0Font.load(document, embeddedFont.inputStream)
+        }
         String fontName = embeddedFont.name ?: font.baseFont
 
         fonts[fontName] = fonts[fontName] ?: [:]


### PR DESCRIPTION
The only way to specify an `EmbeddedFont` is by setting a `File` instance containing the font. This is unpractical if you want to distribute the font as a resource in the application. When the application is packaged, there is no file; to use the resource as an `EmbeddedFont`, it would be necessary to copy its contents to a temporary file.

Since there already is an overload of `PDType0Font.load` method accepting `InputStream` instead of `File`, it makes sense that `EmbeddedFont` could accept both as well. This way resources could be used directly:

```
def font = new EmbeddedFont()
font.inputStream = this.class.classLoader.getResourceAsStream('fonts/OpenSans-Regular.ttf')
```
